### PR TITLE
fixed documented port name for localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A short introduction of this app could easily go here.
 
 * `ember build --environment production` (production)
 * edit the `dist/index.html` and remove the `<base href="/" />`
-* run `node static_server` and open http://localhost:8080/dist
+* run `node static_server` and open [http://localhost:8888/dist/](http://localhost:8888/dist/)
 
 you should see the error in the console `Uncaught UnrecognizedURLError: /dist/`.
 


### PR DESCRIPTION
Has incorrect port and missing trailing slash in docs.
